### PR TITLE
Implement support for vault workload identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,36 @@ in many Ansible versions, so this feature might not always work.
 - Vault namespace used by nomad
 - Default value: **""**
 
+### `nomad_vault_identity_enabled`
+
+- Vault identity enabled will be used by nomad. Mandatory since 1.10. Will only be installed on servers.
+- Default value: **true**
+
+### `nomad_vault_identity_auth_backend_path`
+
+- Vault identity auth path used by nomad. Will only be installed on servers.
+- Default value: **jwt-nomad**
+
+### `nomad_vault_identity_auth_default_aud`
+
+- Vault identity auth aud used by nomad. Will only be installed on servers.
+- Default value: **vault.io**
+
+### `nomad_vault_identity_auth_default_ttl`
+
+- Vault identity auth default ttl used by nomad. Will only be installed on servers.
+- Default value: **1h**
+
+### `nomad_vault_identity_auth_default_env`
+
+- Specify whether the identity JWT may be include in job environment. Will only be installed on servers.
+- Default value: **false**
+
+### `nomad_vault_identity_auth_default_file`
+
+- Specify whether the identity JWT may be include in job as file. Will only be installed on servers.
+- Default value: **false**
+
 ### `nomad_docker_enable`
 
 - Enable docker

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -180,6 +180,13 @@ nomad_vault_tls_skip_verify: false
 nomad_vault_token: ""
 nomad_vault_namespace: ""
 
+nomad_vault_identity_enabled: true
+nomad_vault_identity_auth_backend_path: "jwt-nomad"
+nomad_vault_identity_auth_default_aud: "vault.io"
+nomad_vault_identity_auth_default_ttl: "1h"
+nomad_vault_identity_auth_default_env: false
+nomad_vault_identity_auth_default_file: false
+
 ### Docker
 nomad_docker_enable: "{{ lookup('env', 'NOMAD_DOCKER_ENABLE') | default('false', true) }}"
 nomad_docker_dmsetup: true

--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -73,19 +73,29 @@ acl {
 vault {
     enabled = {{ nomad_vault_enabled | bool | lower }}
     address = "{{ nomad_vault_address }}"
-    allow_unauthenticated = {{ nomad_vault_allow_unauthenticated | bool | lower }}
-    create_from_role = "{{ nomad_vault_create_from_role }}"
-    task_token_ttl = "{{ nomad_vault_task_token_ttl }}"
     ca_file = "{{ nomad_vault_ca_file }}"
     ca_path = "{{ nomad_vault_ca_path }}"
     cert_file = "{{ nomad_vault_cert_file }}"
     key_file = "{{ nomad_vault_key_file }}"
     tls_server_name = "{{ nomad_vault_tls_server_name }}"
     tls_skip_verify = {{ nomad_vault_tls_skip_verify | bool | lower }}
-{%if nomad_node_role != 'client' %}
-    token = "{{ nomad_vault_token }}"
-{% endif %}
     namespace = "{{ nomad_vault_namespace }}"
+    create_from_role = "{{ nomad_vault_create_from_role }}"
+{%if nomad_node_role != 'client' %}
+{% if not nomad_vault_identity_enabled %}
+    allow_unauthenticated = {{ nomad_vault_allow_unauthenticated | bool | lower }}
+    task_token_ttl = "{{ nomad_vault_task_token_ttl }}"
+    token = "{{ nomad_vault_token }}"
+{% else %}
+    jwt_auth_backend_path = "{{ nomad_vault_identity_auth_backend_path }}"
+    default_identity {
+      aud = ["{{ nomad_vault_identity_auth_default_aud }}"]
+      ttl = "{{ nomad_vault_identity_auth_default_ttl }}"
+      env  = {{ nomad_vault_identity_auth_default_env | bool | lower }}
+      file = {{ nomad_vault_identity_auth_default_file | bool | lower }}
+  }
+{% endif %}
+{% endif %}
 }
 
 {% if nomad_telemetry | default(False) | bool == True %}


### PR DESCRIPTION
mandatory since nomad 1.10 when communicating with vault