### PR TITLE
Ensure that jwt_auth_backend path is set for clients as well

### DIFF
--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -81,13 +81,13 @@ vault {
     tls_skip_verify = {{ nomad_vault_tls_skip_verify | bool | lower }}
     namespace = "{{ nomad_vault_namespace }}"
     create_from_role = "{{ nomad_vault_create_from_role }}"
-{%if nomad_node_role != 'client' %}
 {% if not nomad_vault_identity_enabled %}
     allow_unauthenticated = {{ nomad_vault_allow_unauthenticated | bool | lower }}
     task_token_ttl = "{{ nomad_vault_task_token_ttl }}"
     token = "{{ nomad_vault_token }}"
 {% else %}
     jwt_auth_backend_path = "{{ nomad_vault_identity_auth_backend_path }}"
+{% if nomad_node_role != 'client' %}
     default_identity {
       aud = ["{{ nomad_vault_identity_auth_default_aud }}"]
       ttl = "{{ nomad_vault_identity_auth_default_ttl }}"


### PR DESCRIPTION
The [jwt_auth_backend_path](https://developer.hashicorp.com/nomad/docs/configuration/vault#jwt_auth_backend_path) must be set for clients as well to use non-default auth backends.