### PR TITLE
Feature/iden cli fix

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -118,3 +118,4 @@
   become: false
   tags: installation
   delegate_to: 127.0.0.1
+  changed_when: false

--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -82,9 +82,11 @@ vault {
     namespace = "{{ nomad_vault_namespace }}"
     create_from_role = "{{ nomad_vault_create_from_role }}"
 {% if not nomad_vault_identity_enabled %}
+{% if nomad_node_role != 'client' %}
     allow_unauthenticated = {{ nomad_vault_allow_unauthenticated | bool | lower }}
     task_token_ttl = "{{ nomad_vault_task_token_ttl }}"
     token = "{{ nomad_vault_token }}"
+{% endif %}
 {% else %}
     jwt_auth_backend_path = "{{ nomad_vault_identity_auth_backend_path }}"
 {% if nomad_node_role != 'client' %}


### PR DESCRIPTION
see recommendations in [Parameters for Nomad Servers](https://developer.hashicorp.com/nomad/docs/v1.9.x/configuration/vault#parameters-for-nomad-servers-1) (1.9x deprecated, 1.10x removed token based authentication only)